### PR TITLE
PCM-952

### DIFF
--- a/app/assets/sass/elements/_forms.scss
+++ b/app/assets/sass/elements/_forms.scss
@@ -45,6 +45,12 @@ input.margin { margin-bottom: 20px; }
 	padding: 0 1px;
 }
 
+.input-group-btn .btn {
+  padding-top: 9px;
+  padding-bottom: 9px;
+  font-size: 14px;
+}
+
 input.with-close {
 	@include rem('padding-right', 40px);
 }


### PR DESCRIPTION
Changed rem units for the button's font size and padding to pixels, because we need to match the input size, which is specified in pixels. Made more sense than approximating the pixels needed via rem units.
@renujhamtani @vrathee Please review.