### PR TITLE
PCM-1868: Removed excessive request on 401 response

### DIFF
--- a/app/cases/services/searchCaseService.js
+++ b/app/cases/services/searchCaseService.js
@@ -173,6 +173,9 @@ angular.module('RedhatAccess.cases').service('SearchCaseService', [
                     that.searching = false;
                     deferred.resolve(cases);
                 }), angular.bind(that, function (error) {
+                    this.totalCases = 0;
+                    this.total = 0;
+                    this.allCasesDownloaded = true;
                     if(error.xhr.status === 404){
                         this.doFilter(false).then(function () {
                             deferred.resolve(cases);
@@ -205,6 +208,9 @@ angular.module('RedhatAccess.cases').service('SearchCaseService', [
                     that.searching = false;
                     deferred.resolve(cases);
                 }), angular.bind(that, function (error) {
+                    this.totalCases = 0;
+                    this.total = 0;
+                    this.allCasesDownloaded = true;
                     if(error.xhr.status === 404){
                         this.doFilter(false).then(function () {
                             deferred.resolve(cases);


### PR DESCRIPTION
This was caused by infinite-scroll that kept repeating the request, even though it was failing.
@vrathee @gandhikeyur Please review.