### PR TITLE
PCM-776: Added case number highlight

### DIFF
--- a/app/cases/controllers/detailsSection.js
+++ b/app/cases/controllers/detailsSection.js
@@ -12,7 +12,8 @@ angular.module('RedhatAccess.cases').controller('DetailsSection', [
     'AlertService',
     'RHAUtils',
     'translate',
-    function ($scope, $filter, strataService, CaseService, securityService, ProductsService, AUTH_EVENTS, CASE_EVENTS, AlertService, RHAUtils, translate) {
+    'LinkifyService',
+    function ($scope, $filter, strataService, CaseService, securityService, ProductsService, AUTH_EVENTS, CASE_EVENTS, AlertService, RHAUtils, translate, LinkifyService) {
 
         $scope.showExtraInfo = false;
 	    $scope.CaseService = CaseService;
@@ -206,5 +207,11 @@ angular.module('RedhatAccess.cases').controller('DetailsSection', [
             $scope.init();
             //AlertService.clearAlerts();
         });
+
+        $scope.getDescription = function (maxLength) {
+          var text = CaseService.kase.description;
+          if(maxLength !== undefined) text = $filter('substring')(text, maxLength);
+          return LinkifyService.linkifyWithCaseIDs(text);
+        };
     }
 ]);

--- a/app/cases/controllers/discussionSection.js
+++ b/app/cases/controllers/discussionSection.js
@@ -21,7 +21,8 @@ angular.module('RedhatAccess.cases').controller('DiscussionSection', [
     '$sce',
     'gettextCatalog',
     '$filter',
-    function ($scope, $timeout, AttachmentsService, CaseService, DiscussionService, strataService,securityService, $stateParams, AlertService, $modal, $location, $anchorScroll, RHAUtils, EDIT_CASE_CONFIG, AUTH_EVENTS, CASE_EVENTS, $sce, gettextCatalog, $filter) {
+    'LinkifyService',
+    function ($scope, $timeout, AttachmentsService, CaseService, DiscussionService, strataService,securityService, $stateParams, AlertService, $modal, $location, $anchorScroll, RHAUtils, EDIT_CASE_CONFIG, AUTH_EVENTS, CASE_EVENTS, $sce, gettextCatalog, $filter, LinkifyService) {
         $scope.AttachmentsService = AttachmentsService;
         $scope.CaseService = CaseService;
         $scope.securityService = securityService;
@@ -222,7 +223,7 @@ angular.module('RedhatAccess.cases').controller('DiscussionSection', [
                 }
             } else if (comment.text !== undefined) {
                 if (RHAUtils.isNotEmpty(comment.text)) {
-                    parsedHtml = $filter('linky')(comment.text,'_blank');
+                    parsedHtml = LinkifyService.linkifyWithCaseIDs(comment.text);
                 }
             }
             return parsedHtml;

--- a/app/cases/services/linkifyService.js
+++ b/app/cases/services/linkifyService.js
@@ -6,7 +6,7 @@ angular.module('RedhatAccess.cases').service('LinkifyService', [
     this.linkifyWithCaseIDs = function(text) {
       if(RHAUtils.isEmpty(text)) return '';
 
-      var caseIdRegex = /([ \('"]|^)(\d{8})([ \)'"]|$)/g;
+      var caseIdRegex = /([\s\('"]|^)(\d{8})([\s\)'"\.]|$)/g;
       var caseLinkRegex = /<a href="#\/case\/\d{8}">\d{8}<\/a>/g;
       var caseLinksinkifiedText = text.replace(caseIdRegex, '$1<a href="#/case/$2">$2</a>$3');
       var textSegments = caseLinksinkifiedText.split(caseLinkRegex);

--- a/app/cases/services/linkifyService.js
+++ b/app/cases/services/linkifyService.js
@@ -1,0 +1,22 @@
+angular.module('RedhatAccess.cases').service('LinkifyService', [
+  '$filter',
+  'RHAUtils',
+  '$sanitize',
+  function ($filter, RHAUtils, $sanitize) {
+    this.linkifyWithCaseIDs = function(text) {
+      if(RHAUtils.isEmpty(text)) return '';
+
+      var caseIdRegex = /([ \('"]|^)(\d{8})([ \)'"]|$)/g;
+      var caseLinkRegex = /<a href="#\/case\/\d{8}">\d{8}<\/a>/g;
+      var caseLinksinkifiedText = text.replace(caseIdRegex, '$1<a href="#/case/$2">$2</a>$3');
+      var textSegments = caseLinksinkifiedText.split(caseLinkRegex);
+      var caseLinks = caseLinksinkifiedText.match(caseLinkRegex);
+      // merge the elements back together and linkify textSegments
+      var result = [$filter('linky')(textSegments[0], '_blank')];
+      for(var i = 1; i < textSegments.length; i++) {
+        result.push(caseLinks[i-1]);
+        result.push($filter('linky')(textSegments[i], '_blank'));
+      }
+      return result.join('');
+    }
+}]);

--- a/app/cases/views/detailsSection.jade
+++ b/app/cases/views/detailsSection.jade
@@ -16,10 +16,10 @@ section.case-description
       a.margin-left(
         ng-hide='updatingDetails',
         ng-click='editCaseSummary(false)') {{'Cancel'|translate}}
-  span.description.toggled-content.pre-wrap(ng-hide='showExtraInfo') {{CaseService.kase.description | substring:450 }}
+  span.description.toggled-content.pre-wrap(ng-hide='showExtraInfo', ng-bind-html='getDescription(450)')
   div
     a(ng-click='toggleExtraInfo()', ng-hide='showExtraInfo', translate='') View More
-  span.description.pre-wrap(ng-show='showExtraInfo') {{CaseService.kase.description}}
+  span.description.pre-wrap(ng-show='showExtraInfo', ng-bind-html='getDescription()')
   div#case-description-extra-info(ng-class="showExtraInfo ? 'case-description-extra-info active' : 'case-description-extra-info'")
     form(name='detailsForm')
       section.config-options

--- a/app/chromed.html
+++ b/app/chromed.html
@@ -156,6 +156,7 @@
     window.deps.push("/cases/services/recommendationsService.js");
     window.deps.push("/cases/services/searchBoxService.js");
     window.deps.push("/cases/services/searchCaseService.js");
+    window.deps.push("/cases/services/linkifyService.js");
 
     // window.deps.push("/common/common.module.js");
     // window.deps.push("/common/header.module.js");

--- a/app/index.html
+++ b/app/index.html
@@ -158,6 +158,7 @@
     <script src="cases/directives/manageGroupList.js"></script>
     <script src="cases/directives/manageGroupUsers.js"></script>
     <script src="cases/services/manageGroupsService.js"></script>
+    <script src="cases/services/linkifyService.js"></script>
 
     <script src="cases/directives/listNewAttachments.js"></script>
     <script src="cases/directives/ownerSelect.js"></script>


### PR DESCRIPTION
@gandhikeyur Please review.
I talked with spenser and we decided that adding some hash symbol to indicate case number reference is unfeasible, due to the number of existing cases and the fact that customers would need to be forced to use it. So we decided to proceed with the regex solution; the priority is to prefer non-highlighted occurrences rather than having false positives. Let me know what you think.