### PR TITLE
PCM-3350: Fix for cases not being fetched

### DIFF
--- a/app/cases/controllers/bookmarkedAccountSelect.js
+++ b/app/cases/controllers/bookmarkedAccountSelect.js
@@ -27,8 +27,10 @@ export default class BookmarkedAccountSelect {
             }
         };
 
-        $scope.$watch('selectedAccount', function () {
-            $scope.selectedAccountChanged();
+        $scope.$watch('selectedAccount', function (newValue, oldValue) {
+            if(newValue != oldValue) {
+                $scope.selectedAccountChanged();
+            }
         });
 
         if (!AccountBookmarkService.loading) {

--- a/app/cases/services/searchCaseService.js
+++ b/app/cases/services/searchCaseService.js
@@ -66,7 +66,6 @@ export default class SearchCaseService {
         var queryString = '';
 
         this.doFilter = function (checkIsInternal) {
-            if (this.searching) return;
             this.previousGroupFilter = this.caseParameters.group;
             queryString = '';
 


### PR DESCRIPTION
@renujhamtani @vrathee @gandhikeyur Please review, this fixes the case-loading blocker

https://projects.engineering.redhat.com/browse/PCM-3350

What happens in PCM is that if the request for cases (/case/filter with SSO in the payload) fails, PCM runs another query, this time without the SSO. The one line in `searchCaseService.js` prevented the other request form being executed. Not sure why two requests need to be executed, or why the first one fails. Strata team should still investigate why the first requests fails with 404.