### PR TITLE
PCM-3339: Fixed breadcrumbs for Search and Groups

### DIFF
--- a/app/cases/controllers/advancedSearchController.js
+++ b/app/cases/controllers/advancedSearchController.js
@@ -151,5 +151,16 @@ export default class AdvancedSearchController {
             init();
         }
         $scope.$on(AUTH_EVENTS.loginSuccess, init);
+
+
+        // set breadcrumbs
+        if (window.chrometwo_require !== undefined) {
+            breadcrumbs = [
+                ['Support', '/support/'],
+                ['Support Cases', '/support/cases/'],
+                ['Search']
+            ];
+            updateBreadCrumb();
+        }
     }
 }

--- a/app/cases/controllers/manageGroups.js
+++ b/app/cases/controllers/manageGroups.js
@@ -20,5 +20,15 @@ export default class ManageGroups {
                 $scope.init();
             });
         }
+
+        // set breadcrumbs
+        if (window.chrometwo_require !== undefined) {
+            breadcrumbs = [
+                ['Support', '/support/'],
+                ['Support Cases', '/support/cases/'],
+                ['Case Groups']
+            ];
+            updateBreadCrumb();
+        }
     }
 }


### PR DESCRIPTION
@vrathee @gandhikeyur Please review.

@renujhamtani While fixing this I noticed there are two routes we probably don't use anywhere. Both `editGroup` and `defaultGroup` routes seem to have been replaced by the manage groups interface. Should I remove those routes?