### PR TITLE
PCM-3257: Fixing init behavior

### DIFF
--- a/app/cases/views/edit.jade
+++ b/app/cases/views/edit.jade
@@ -1,41 +1,41 @@
 .page-header(rha-header='', page='')
-div.edit(ng-show='securityService.loginStatus.isLoggedIn && !HeaderService.pageLoadFailure && CaseService.sfdcIsHealthy && securityService.loginStatus.userAllowedToManageCases')
+div.edit(ng-if='securityService.loginStatus.isLoggedIn && !HeaderService.pageLoadFailure && CaseService.sfdcIsHealthy && securityService.loginStatus.userAllowedToManageCases')
   .row.row-very-short
     div.section.main.col-md-8
       .row.row-very-short
-        h1.page-title(translate) CASE {{CaseService.kase.case_number}}
-      .row.row-very-short(ng-if='securityService.loginStatus.authedUser.is_internal')
-        span.label.label-mar-right.label-info(ng-show='CaseService.kase.hotfix_requested') {{'Hot Fix Requested'|translate}}
-        span.label.label-mar-right.label-success(ng-show='CaseService.kase.hotfix_delivered') {{'Hot Fix Delivered'|translate}}
-        span.label.label-mar-right.label-danger(ng-show='CaseService.account.is_special_handling_required') {{'Special Handling'|translate}}
+        h1.page-title(translate) CASE {{$parent.CaseService.kase.case_number}}
+      .row.row-very-short(ng-if='$parent.securityService.loginStatus.authedUser.is_internal')
+        span.label.label-mar-right.label-info(ng-show='$parent.CaseService.kase.hotfix_requested') {{'Hot Fix Requested'|translate}}
+        span.label.label-mar-right.label-success(ng-show='$parent.CaseService.kase.hotfix_delivered') {{'Hot Fix Delivered'|translate}}
+        span.label.label-mar-right.label-danger(ng-show='$parent.CaseService.account.is_special_handling_required') {{'Special Handling'|translate}}
       .row.row-very-short
-        b {{CaseService.kase.summary}}
+        b {{$parent.CaseService.kase.summary}}
       .row.row-very-short
-        span(id="rha-product-version") {{CaseService.kase.product}} {{CaseService.kase.version}}
+        span(id="rha-product-version") {{$parent.CaseService.kase.product}} {{$parent.CaseService.kase.version}}
       .row.row-very-short
-        span(id="rha-case-filedOn" translate)  Filed on {{CaseService.kase.created_date}} by {{CaseService.kase.created_by}}
+        span(id="rha-case-filedOn" translate)  Filed on {{$parent.CaseService.kase.created_date}} by {{$parent.CaseService.kase.created_by}}
       .row.row-very-short
-        span {{'Assigned to'|translate}} {{CaseService.kase.owner}}
-      .row.row-very-short(ng-if='securityService.loginStatus.authedUser.is_internal')
-        span(translate) Account number : {{CaseService.account.number}}
-      .row.row-very-short(ng-if='securityService.loginStatus.authedUser.is_internal')
-        span(translate) Account name : {{CaseService.account.name}}
-        span(rha-bookmark-account, account='CaseService.account')
+        span {{'Assigned to'|translate}} {{$parent.CaseService.kase.owner}}
+      .row.row-very-short(ng-if='$parent.securityService.loginStatus.authedUser.is_internal')
+        span(translate) Account number : {{$parent.CaseService.account.number}}
+      .row.row-very-short(ng-if='$parent.securityService.loginStatus.authedUser.is_internal')
+        span(translate) Account name : {{$parent.CaseService.account.name}}
+        span(rha-bookmark-account, account='$parent.CaseService.account')
       .row.row-very-short
-        a(href='/support/offerings/production/sla.html', target='_blank') {{CaseService.kase.entitlement.sla}} {{'Support Level'|translate}}
-      .row.row-very-short(ng-show='EDIT_CASE_CONFIG.showDescription')
-        div(rha-casedescription='', loading='loading.kase')
-      .row.row-very-short(ng-show='EDIT_CASE_CONFIG.showDetails')
-        div(rha-casedetails='', compact='false', loading='loading.kase')
+        a(href='/support/offerings/production/sla.html', target='_blank') {{$parent.CaseService.kase.entitlement.sla}} {{'Support Level'|translate}}
+      .row.row-very-short(ng-show='$parent.EDIT_CASE_CONFIG.showDescription')
+        div(rha-casedescription='', loading='$parent.loading.kase')
+      .row.row-very-short(ng-show='$parent.EDIT_CASE_CONFIG.showDetails')
+        div(rha-casedetails='', compact='false', loading='$parent.loading.kase')
           rha-casedetails
       section.case-discussion
         .row
           .col-xs-12(rha-emailnotifyselect='')
 
     .aside.col-md-4
-      .spinner.spinner-inline(ng-show='RecommendationsService.loadingRecommendations')
-      #rha-recommendation-section.recommendations.aside-section(rha-editcaserecommendations='', ng-hide='(RecommendationsService.recommendations.length === 0 && RecommendationsService.handPickedRecommendations.length === 0 && RecommendationsService.pinnedRecommendations.length === 0) || RecommendationsService.loadingRecommendations')
+      .spinner.spinner-inline(ng-show='$parent.RecommendationsService.loadingRecommendations')
+      #rha-recommendation-section.recommendations.aside-section(rha-editcaserecommendations='', ng-hide='($parent.RecommendationsService.recommendations.length === 0 && $parent.RecommendationsService.handPickedRecommendations.length === 0 && $parent.RecommendationsService.pinnedRecommendations.length === 0) || RecommendationsService.loadingRecommendations')
       div#case-escalation.case-escalation(rha-requestescalation='')
   .row
     .col-xs-12
-      div(rha-casediscussion='', loading='loading.comments')
+      div(rha-casediscussion='', loading='$parent.loading.comments')

--- a/app/cases/views/new.jade
+++ b/app/cases/views/new.jade
@@ -1,14 +1,14 @@
 div(rha-header='', page='newCase')
-.page-header(ng-show='securityService.loginStatus.isLoggedIn && !HeaderService.pageLoadFailure && CaseService.sfdcIsHealthy && securityService.loginStatus.userAllowedToManageCases')
+.page-header(ng-if='securityService.loginStatus.isLoggedIn && !HeaderService.pageLoadFailure && CaseService.sfdcIsHealthy && securityService.loginStatus.userAllowedToManageCases')
     .row.row-short
-        div(ng-class="(RecommendationsService.recommendations.length === 0 || ProductsService.productsLoading) ? 'col-sm-12' : 'col-sm-8'")
-            div(ng-show='ProductsService.productsLoading')
+        div(ng-class="($parent.RecommendationsService.recommendations.length === 0 || $parent.ProductsService.productsLoading) ? 'col-sm-12' : 'col-sm-8'")
+            div(ng-show='$parent.ProductsService.productsLoading')
                 .spinner
-            div(ng-hide='ProductsService.productsLoading')
+            div(ng-hide='$parent.ProductsService.productsLoading')
                 section.case-new
                     section.config-options
                         #rha-case-main-options
-                            div(ng-if='securityService.loginStatus.authedUser.is_internal')
+                            div(ng-if='$parent.securityService.loginStatus.authedUser.is_internal')
                                 label(for='rha-account-number',translate,translate-comment="Noun") Account
                                 div(rha-accountselect='')
                                 label(for='rha-owners-select',translate,translate-comment="Noun") Owner
@@ -20,84 +20,84 @@ div(rha-header='', page='newCase')
                             label(translate,translate-comment="Noun") Problem Statement
                             input#rha-case-summary.form-control(
                             maxlength='255',
-                            ng-disabled='!securityService.loginStatus.isLoggedIn || CaseService.submittingCase',
-                            ng-change='onSummaryChange($event)',
-                            ng-model='CaseService.kase.summary'
-                            ng-focus="CaseService.updatingNewCaseSummary=true",
-                            ng-blur="CaseService.updatingNewCaseSummary=false")
+                            ng-disabled='!$parent.securityService.loginStatus.isLoggedIn || $parent.CaseService.submittingCase',
+                            ng-change='$parent.onSummaryChange($event)',
+                            ng-model='$parent.CaseService.kase.summary'
+                            ng-focus="$parent.CaseService.updatingNewCaseSummary=true",
+                            ng-blur="$parent.CaseService.updatingNewCaseSummary=false")
                             .loader
-                                div(ng-show='CaseService.updatingNewCaseSummary && RecommendationsService.loadingRecommendations')
+                                div(ng-show='$parent.CaseService.updatingNewCaseSummary && $parent.RecommendationsService.loadingRecommendations')
                                     .circle &nbsp;
                                     .circle &nbsp;
                                     .circle &nbsp;
-                            label.label-small-mar.pre-wrap {{CaseService.problemString}}
+                            label.label-small-mar.pre-wrap {{$parent.CaseService.problemString}}
                             textarea(name='', id='rha-problem',
                             style='width: 100%; height: 75px; max-width: 100%;',
-                            ng-model='CaseService.kase.problem',
-                            ng-change='onProblemChange($event)',
-                            ng-disabled='!securityService.loginStatus.isLoggedIn || CaseService.submittingCase'
-                            ng-focus="CaseService.updatingProblemString=true",
-                            ng-blur="CaseService.updatingProblemString=false")
+                            ng-model='$parent.CaseService.kase.problem',
+                            ng-change='$parent.onProblemChange($event)',
+                            ng-disabled='!$parent.securityService.loginStatus.isLoggedIn || $parent.CaseService.submittingCase'
+                            ng-focus="$parent.CaseService.updatingProblemString=true",
+                            ng-blur="$parent.CaseService.updatingProblemString=false")
                             .loader
-                                div(ng-show='CaseService.updatingProblemString && RecommendationsService.loadingRecommendations')
+                                div(ng-show='$parent.CaseService.updatingProblemString && $parent.RecommendationsService.loadingRecommendations')
                                     .circle &nbsp;
                                     .circle &nbsp;
                                     .circle &nbsp;
-                            label.pre-wrap.label-small-mar {{CaseService.environmentString}}
+                            label.pre-wrap.label-small-mar {{$parent.CaseService.environmentString}}
                             textarea(name='', id='rha-environment',
                             style='width: 100%; height: 75px; max-width: 100%;',
-                            ng-model='CaseService.kase.environment',
-                            ng-change='onEnvironmentChange($event)',
-                            ng-disabled='!securityService.loginStatus.isLoggedIn || CaseService.submittingCase'
-                            ng-focus="CaseService.updatingEnvironmentString=true",
-                            ng-blur="CaseService.updatingEnvironmentString=false")
+                            ng-model='$parent.CaseService.kase.environment',
+                            ng-change='$parent.onEnvironmentChange($event)',
+                            ng-disabled='!$parent.securityService.loginStatus.isLoggedIn || $parent.CaseService.submittingCase'
+                            ng-focus="$parent.CaseService.updatingEnvironmentString=true",
+                            ng-blur="$parent.CaseService.updatingEnvironmentString=false")
                             .loader
-                                div(ng-show='CaseService.updatingEnvironmentString && RecommendationsService.loadingRecommendations')
+                                div(ng-show='$parent.CaseService.updatingEnvironmentString && $parent.RecommendationsService.loadingRecommendations')
                                     .circle &nbsp;
                                     .circle &nbsp;
                                     .circle &nbsp;
-                            label.pre-wrap.label-small-mar {{CaseService.occuranceString}}
+                            label.pre-wrap.label-small-mar {{$parent.CaseService.occuranceString}}
                             textarea(name='', id='rha-occurance',
                             style='width: 100%; height: 75px; max-width: 100%;',
-                            ng-model='CaseService.kase.occurance',
-                            ng-change='onOccuranceChange($event)',
-                            ng-disabled='!securityService.loginStatus.isLoggedIn || CaseService.submittingCase'
-                            ng-focus="CaseService.updatingOccuranceString=true",
-                            ng-blur="CaseService.updatingOccuranceString=false")
+                            ng-model='$parent.CaseService.kase.occurance',
+                            ng-change='$parent.onOccuranceChange($event)',
+                            ng-disabled='!$parent.securityService.loginStatus.isLoggedIn || $parent.CaseService.submittingCase'
+                            ng-focus="$parent.CaseService.updatingOccuranceString=true",
+                            ng-blur="$parent.CaseService.updatingOccuranceString=false")
                             .loader
-                                div(ng-show='CaseService.updatingOccuranceString && RecommendationsService.loadingRecommendations')
+                                div(ng-show='$parent.CaseService.updatingOccuranceString && $parent.RecommendationsService.loadingRecommendations')
                                     .circle &nbsp;
                                     .circle &nbsp;
                                     .circle &nbsp;
-                            label.pre-wrap.label-small-mar {{CaseService.urgencyString}}
+                            label.pre-wrap.label-small-mar {{$parent.CaseService.urgencyString}}
                             textarea(name='', id='rha-urgency',
                             style='width: 100%; height: 75px; max-width: 100%;',
-                            ng-model='CaseService.kase.urgency',
-                            ng-change='onUrgencyChange($event)',
-                            ng-disabled='!securityService.loginStatus.isLoggedIn || CaseService.submittingCase'
-                            ng-focus="CaseService.updatingUrgencyString=true",
-                            ng-blur="CaseService.updatingUrgencyString=false")
+                            ng-model='$parent.CaseService.kase.urgency',
+                            ng-change='$parent.onUrgencyChange($event)',
+                            ng-disabled='!$parent.securityService.loginStatus.isLoggedIn || $parent.CaseService.submittingCase'
+                            ng-focus="$parent.CaseService.updatingUrgencyString=true",
+                            ng-blur="$parent.CaseService.updatingUrgencyString=false")
                             .loader
-                                div(ng-show='CaseService.updatingUrgencyString && RecommendationsService.loadingRecommendations')
+                                div(ng-show='$parent.CaseService.updatingUrgencyString && $parent.RecommendationsService.loadingRecommendations')
                                     .circle &nbsp;
                                     .circle &nbsp;
                                     .circle &nbsp;
-                            div(style="margin-top: 10px", ng-show='NEW_CASE_CONFIG.showAttachments && securityService.loginStatus.authedUser.can_add_attachments')
+                            div(style="margin-top: 10px", ng-show='$parent.NEW_CASE_CONFIG.showAttachments && $parent.securityService.loginStatus.authedUser.can_add_attachments')
                                 b {{'Get faster results.'|translate}}
                                 | &nbsp; {{'Attaching logs or other diagnostics files typically results in faster resolution.'|translate}}
-                                div(ng-bind-html='AttachmentsService.parseArtifactHtml()')
+                                div(ng-bind-html='$parent.AttachmentsService.parseArtifactHtml()')
                                 div(rha-listnewattachments='')
-                                div(ng-hide='ie8 || ie9', rha-attachlocalfile='', disabled='CaseService.submittingCase')
-                                .rha-bottom-border(ng-hide='ie8 && NEW_CASE_CONFIG.isPCM || ie9 && NEW_CASE_CONFIG.isPCM')
-                                    .row.rha-create-field(ng-hide='CaseService.submittingCase')
+                                div(rha-attachlocalfile='', disabled='$parent.CaseService.submittingCase')
+                                .rha-bottom-border(ng-hide='$parent.NEW_CASE_CONFIG.isPCM')
+                                    .row.rha-create-field(ng-hide='$parent.CaseService.submittingCase')
                                         .col-xs-12
-                                            div(ng-show='NEW_CASE_CONFIG.showServerSideAttachments')
+                                            div(ng-show='$parent.NEW_CASE_CONFIG.showServerSideAttachments')
                                                 .server-attach-header {{'Server File(s) To Attach:'|translate}}
                                                     // TODO -- This needs to be fixed, getting: Multiple directives [ngController, rhaChoicetree (module: RedhatAccess.ui-utils)] asking for new/isolated scope on: <div rha-choicetree="" ng-model="attachmentTree" ng-controller="BackEndAttachmentsCtrl" class="ng-pristine ng-untouched ng-valid">
                                                     //div(rha-choicetree='',
                                                     //ng-model='attachmentTree',
                                                     //ng-controller='BackEndAttachmentsCtrl')
-                                div(ng-show='ie8 && NEW_CASE_CONFIG.isPCM || ie9 && NEW_CASE_CONFIG.isPCM')
+                                div(ng-show='$parent.NEW_CASE_CONFIG.isPCM')
                                     form#fileUploaderForm(enctype="multipart/form-data", method="post",target="upload_target")
                                         div
                                             .row.rha-create-field
@@ -107,7 +107,7 @@ div(rha-header='', page='newCase')
                                                     div(style='float: left; word-wrap: break-word; width: 100%;') {{fileName}}
                                             .row.rha-create-field
                                                 .col-xs-12(style='font-size: 80%;')
-                                                    div(ng-bind-html='parseArtifactHtml()')
+                                                    div(ng-bind-html='$parent.parseArtifactHtml()')
                                                 .col-xs-12(style='font-size: 80%;')
                                                     span {{'File names must be less than 80 characters. Maximum file size for web-uploaded attachments is 1 GB. Please FTP larger files to dropbox.redhat.com.'|translate}}&nbsp;
                                                     span
@@ -118,7 +118,7 @@ div(rha-header='', page='newCase')
                                                     style='float: left;',
                                                     type='text',
                                                     name='description',
-                                                    ng-model='ieFileDescription',
+                                                    ng-model='$parent.ieFileDescription',
                                                     placeholder="{{'File description'|translate}}")
                                     iframe#upload_target(name='upload_target', style='width: 0; height: 0; border: 0px solid #fff;')
                         #rha-case-more-options.rha-case-more-options
@@ -127,48 +127,48 @@ div(rha-header='', page='newCase')
                                 span.glyphicon.glyphicon-question-sign.link(uib-tooltip-html='"<div><span>{{"To Learn more view the" |translate }}</span><br /><a href=\'/support/offerings/production/sla.html\' target=\'_blank\'>{{"Production Support Service Level Agreement"|translate}}</a></div>"',tabindex='0',tooltip-trigger="click")
                             select#rha-supportLevel-select(
                             chosen,
-                            ng-model="CaseService.entitlement",
-                            ng-change="CaseService.onChangeFTSCheck()",
+                            ng-model="$parent.CaseService.entitlement",
+                            ng-change="$parent.CaseService.onChangeFTSCheck()",
                             width="'100%'",
-                            ng-options="entitlement as entitlement for entitlement in CaseService.entitlements")
+                            ng-options="entitlement as entitlement for entitlement in $parent.CaseService.entitlements")
                                 option(value="")
                             label {{'Severity' |translate}}
                             div(rha-severityselect,
-                            created-case="CaseService.kase",
-                            severity-change="CaseService.onChangeFTSCheck()",
-                            severity-disabled="CaseService.submittingCase",
-                            severities="CaseService.severities")
-                            div(ng-show="CaseService.showFts()")
+                            created-case="$parent.CaseService.kase",
+                            severity-change="$parent.CaseService.onChangeFTSCheck()",
+                            severity-disabled="$parent.CaseService.submittingCase",
+                            severities="$parent.CaseService.severities")
+                            div(ng-show="$parent.CaseService.showFts()")
                                 label#rha-24X7_Support(translate,translate-comment="Noun") 24x7 Support
                                 input(
                                 type="checkbox",
-                                ng-model="CaseService.fts")
-                            div(ng-show="CaseService.showFts()")
+                                ng-model="$parent.CaseService.fts")
+                            div(ng-show="$parent.CaseService.showFts()")
                                 label#rha-24X7_Contact(translate,translate-comment="Noun") 24x7 Contact
-                                input#rha-24X7_Contact_input(ng-model="CaseService.fts_contact")
+                                input#rha-24X7_Contact_input(ng-model="$parent.CaseService.fts_contact")
                             label(for='email-notifications',translate) Send Email Notifications to
-                            .spinner.spinner-inline(ng-show='!securityService.loginStatus.isLoggedIn  || CaseService.usersLoading || securityService.loggingIn')
+                            .spinner.spinner-inline(ng-show='!$parent.securityService.loginStatus.isLoggedIn  || $parent.CaseService.usersLoading || $parent.securityService.loggingIn')
                             select(
                             chosen,
                             multiple,
                             data-placeholder="{{'Select a User'|translate}}",
-                            ng-disabled='updatingList || CaseService.submittingCase',
-                            ng-model='notifiedUsers',
+                            ng-disabled='$parent.updatingList || $parent.CaseService.submittingCase',
+                            ng-model='$parent.notifiedUsers',
                             id='rha-email-notify-select',
                             width='"100%"',
-                            ng-options="user.sso_username as (user.first_name+' '+user.last_name+' <'+user.sso_username+'>') for user in usersOnAccount | orderBy:['first_name','last_name']")
+                            ng-options="user.sso_username as (user.first_name+' '+user.last_name+' <'+user.sso_username+'>') for user in $parent.usersOnAccount | orderBy:['first_name','last_name']")
                                 option(value="")
 
 
                             label(translate,translate-comment="Noun") Case Group (Optional)
-                            div(rha-groupselect='', ng-init="setSearchOptions('false')")
+                            div(rha-groupselect='', ng-init="$parent.setSearchOptions('false')")
                         .row
                             //- TODO make remove local storage once implemented
                             .col-sm-12
                                 button.btn.btn-app(
-                                ng-disabled='CaseService.submittingCase || CaseService.newCaseIncomplete',
-                                ng-hide='CaseService.submittingCase',
-                                ng-click='doSubmit($event)', translate,translate-comment="Verb") Submit
-                                a.margin-left(href='#/case/list',ng-hide='CaseService.submittingCase',translate,translate-comment="Verb") Cancel
-        .aside.col-sm-4.new-recommendations-column#new-recommendations-column(ng-hide="RecommendationsService.recommendations.length === 0 || ProductsService.productsLoading")
-            div.affixed-recommendations(rha-newcaserecommendations='', items-per-page='recommendationsPerPage')
+                                ng-disabled='$parent.CaseService.submittingCase || $parent.CaseService.newCaseIncomplete',
+                                ng-hide='$parent.CaseService.submittingCase',
+                                ng-click='$parent.doSubmit($event)', translate,translate-comment="Verb") Submit
+                                a.margin-left(href='#/case/list',ng-hide='$parent.CaseService.submittingCase',translate,translate-comment="Verb") Cancel
+        .aside.col-sm-4.new-recommendations-column#new-recommendations-column(ng-hide="$parent.RecommendationsService.recommendations.length === 0 || $parent.ProductsService.productsLoading")
+            div.affixed-recommendations(rha-newcaserecommendations='', items-per-page='$parent.recommendationsPerPage')


### PR DESCRIPTION
@gandhikeyur (@engineersamuel) Please review.

A bit of background on why is this needed, previously, we got the authentication cookie (rh_sso) right out of SSO when logging in, currently we get the cookie (rh_jwt) when the session.js initializes. So, we need to delay ALL the calls to strata until that is done. On edit and new case views, some requests were firing even before that, because some components perform their init independent on the authentication, so I just replaced `ng-show` with `ng-if` to make sure the components are initialized only after auth succeeds.