### PR TITLE
PCM-3609: Fixing public search link

### DIFF
--- a/app/cases/controllers/advancedSearchController.js
+++ b/app/cases/controllers/advancedSearchController.js
@@ -126,7 +126,7 @@ export default class AdvancedSearchController {
         $scope.bookmarkPublicLink = () => {
             if($scope.selectedBookmark) {
                 const bm = $scope.selectedBookmark;
-                return $state.href("advancedSearch", {query: bm.query, sortBy: `${bm.sort.sortField}_${bm.sort.sortOrder}`}, {inherit:false, absolute: true});
+                return $state.href("advancedSearch", {query: bm.query, sortBy: `${bm.sort.sortField}_${bm.sort.sortOrder}`}, {inherit:false});
             }
         };
 


### PR DESCRIPTION
@vrathee @renujhamtani Please review.

https://projects.engineering.redhat.com/browse/PCM-3609

The `absolute: true` generated absolute URL without the proper path. To fix this, I removed generate relative url, and let browser handle the conversion to absolute. Opening in a new tab and copying with right-click still works fine.