### PR TITLE
Fixing translations

### DIFF
--- a/app/cases/views/discussionSection.jade
+++ b/app/cases/views/discussionSection.jade
@@ -131,10 +131,10 @@ ul#tab_list.nav.nav-tabs(role="tablist")
       .row.row-short
         .col-sm-7
           span#notesNotice.uploadNotice
-            span.progressCount(translate) {{noteCharactersLeft}} {{'characters left.'|translate}}
+            span.progressCount() {{noteCharactersLeft}} {{'characters left.'|translate}}
         .col-sm-5
           .pull-right
-            button.btn.btn-app(ng-click="updateNotes()", ng-disabled='CaseService.updatingCase || !notesForm.$dirty',translate='') {{'Update'|translate}}
+            button.btn.btn-app(ng-click="updateNotes()", ng-disabled='CaseService.updatingCase || !notesForm.$dirty') {{'Update'|translate}}
             button.btn.btn-app.margin-left(ng-click="discardNotes()", ng-disabled='CaseService.updatingCase || !notesForm.$dirty') {{'Discard Changes'|translate}}
   #pane4.tab-pane(ng-if="securityService.loginStatus.authedUser.is_internal || CaseService.kase.bugzillas.bugzilla.length > 0", ng-class='{"active": bugzillas}')
     div(rha-listbugzillas)
@@ -157,5 +157,5 @@ ul#tab_list.nav.nav-tabs(role="tablist")
       .row.row-short(ng-if="securityService.loginStatus.authedUser.is_internal")
         .col-sm-6
           .pull-left
-            button.btn.btn-app(ng-click="updateActionPlan()", ng-disabled='CaseService.updatingCase || !actionPlanForm.$dirty',translate='') {{'Update'|translate}}
+            button.btn.btn-app(ng-click="updateActionPlan()", ng-disabled='CaseService.updatingCase || !actionPlanForm.$dirty') {{'Update'|translate}}
             button.btn.btn-app.margin-left(ng-click="discardActionPlan()", ng-disabled='CaseService.updatingCase || !actionPlanForm.$dirty') {{'Discard Changes'|translate}}

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
         "generate-dist-common-translates": "angular-gettext-cli --files 'node_modules/redhat_access_pcm_ascension_common/dist/redhat_access_pcm_ascension_common.js'  --dest \"./app/i18n/template-common.pot\"",
         "generate-view-common-translates": "angular-gettext-cli --files 'node_modules/redhat_access_pcm_ascension_common/app/@(common|security)/views/*.html'  --dest \"./app/i18n/template-common-views.pot\"",
         "merge-translates": "msgcat app/i18n/template-dist.pot app/i18n/template-views.pot app/i18n/template-common.pot app/i18n/template-common-views.pot > app/i18n/template.pot",
-        "generate-translates": "npm run generate-html && npm run generate-dist-translates && npm run generate-view-translates && npm run generate-dist-common-translates && npm run generate-view-common-translates && npm run merge-translates"
+        "clear-generated-files": "rimraf 'app/cases/views/!(compact).html' 'app/escalation/views/*.html' 'app/log_viewer/views/*.html' 'app/search/views/*.html' 'node_modules/redhat_access_pcm_ascension_common/app/security/views/*.html' 'node_modules/redhat_access_pcm_ascension_common/app/common/views/!(treenode|treeview-selector).html' 'app/i18n/@(template-common|template-common-views|template-dist|template-views).pot'",
+        "generate-translates": "npm run generate-html && npm run generate-dist-translates && npm run generate-view-translates && npm run generate-dist-common-translates && npm run generate-view-common-translates && npm run merge-translates && npm run clear-generated-files"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,15 @@
         "server-prod": "webpack-dev-server --config webpack-production.config.js --history-api-fallback --inline --progress --port 9000",
         "test-watch": "karma start --auto-watch --no-single-run",
         "start": "cp hooks/pre-commit .git/hooks/ && npm run server-inline",
-        "start-prod": "npm run server-prod"
+        "start-prod": "npm run server-prod",
+
+        "generate-html": "jade --pretty app/cases/views app/escalation/views app/log_viewer/views app/search/views node_modules/redhat_access_pcm_ascension_common/app/security/views/ node_modules/redhat_access_pcm_ascension_common/app/common/views/",
+        "generate-dist-translates": "angular-gettext-cli --files 'dist/pcm.js'  --dest \"./app/i18n/template-dist.pot\"",
+        "generate-view-translates": "angular-gettext-cli --files 'app/**/*.html'  --dest \"./app/i18n/template-views.pot\"",
+        "generate-dist-common-translates": "angular-gettext-cli --files 'node_modules/redhat_access_pcm_ascension_common/dist/redhat_access_pcm_ascension_common.js'  --dest \"./app/i18n/template-common.pot\"",
+        "generate-view-common-translates": "angular-gettext-cli --files 'node_modules/redhat_access_pcm_ascension_common/app/@(common|security)/views/*.html'  --dest \"./app/i18n/template-common-views.pot\"",
+        "merge-translates": "msgcat app/i18n/template-dist.pot app/i18n/template-views.pot app/i18n/template-common.pot app/i18n/template-common-views.pot > app/i18n/template.pot",
+        "generate-translates": "npm run generate-html && npm run generate-dist-translates && npm run generate-view-translates && npm run generate-dist-common-translates && npm run generate-view-common-translates && npm run merge-translates"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
@vrathee @gandhikeyur @renujhamtani Please review.

https://projects.engineering.redhat.com/browse/PCM-3632

From my limited knowledge of translations, I put together a new way to generate translation templates. Instead of grunt I use angular-gettext-cli, and the generation is done in two parts:

- scraping the dist .js file
- srcaping the view files

Since we no longer generate .html, and since the angular-gettext-cli doesn't understand .jade, I had to add a compilation from jade to html as well. Please, think about this PR and ask questions if something doesn't feel right.

To build the templates you need to install **angular-gettext-cli** with `npm install -g angular-gettext-cli`, **jade** with  `npm install -g jade` and **msgcat** (that was bundled with my fedora already).

Then the procedure is the following:

1. Do a regular build with `npm run build`
2. Generate translate templates with `npm run generate-translates`