### PR TITLE
PCM-3954: Not showing already selected internal watchers

### DIFF
--- a/app/cases/controllers/emailNotifySelect.js
+++ b/app/cases/controllers/emailNotifySelect.js
@@ -40,7 +40,8 @@ export default class EmailNotifySelect {
         $scope.searchRHUsers = (searchQuery) => {
             const query = searchQuery.toLowerCase();
 
-            return _.filter(CaseService.redhatUsers, (user) => `${user.first_name} ${user.last_name} ${user.sso_username}`.toLowerCase().indexOf(query) > -1);
+            // return users that are not selected and match the searchQuery
+            return _.filter(CaseService.redhatUsers, (user) => $scope.selectedUsers.indexOf(user.sso_username) == -1 && `${user.first_name} ${user.last_name} ${user.sso_username}`.toLowerCase().indexOf(query) > -1);
         };
 
         $scope.isCurrentUserWatcher = () => $scope.selectedUsers.indexOf(securityService.loginStatus.authedUser.sso_username) > -1;


### PR DESCRIPTION
@vrathee @gandhikeyur Please review. If an internal watcher is already selected, we don't want to show that user in the search.

https://projects.engineering.redhat.com/browse/PCM-3954