### PR TITLE
Removing the console error that pops up if strata response for account is empty

### DIFF
--- a/app/loader.js
+++ b/app/loader.js
@@ -96,7 +96,7 @@
                   }
                   securityService.validateLogin(false).then(function (authedUser) {
                     var account = securityService.loginStatus.account;
-                    if(account !== undefined && account.is_secured_support !== undefined && account.is_secured_support === true){
+                    if(account && account.is_secured_support){
                       strata.setRedhatClientID("secure_case_management_1.0");
                       strata.setStrataHostname('https://' + host.replace('access.', 'access.us.'));
                       NEW_CASE_CONFIG.showRecommendations = false;

--- a/app/main.module.js
+++ b/app/main.module.js
@@ -220,7 +220,7 @@ if (ENVIRONMENT === 'gs4') {
             window.sessionjs.onInit(() => {
                 securityService.validateLogin(false).then(function (authedUser) {
                 var account = securityService.loginStatus.account;
-                if (account !== undefined && account.is_secured_support !== undefined && account.is_secured_support === true) {
+                if ( account && account.is_secured_support ) {
                     strata.setRedhatClientID("secure_case_management_1.0");
                     strata.setStrataHostname('https://' + host.replace('access.', 'access.us.'));
                     NEW_CASE_CONFIG.showRecommendations = false;


### PR DESCRIPTION
@jtrantin @renujhamtani Please review.. This fixes the console error we get if strata returns a 404 for account..