### PR TITLE
PCM-4356: Adding internal authedUser to RH users list

### DIFF
--- a/app/cases/services/caseService.js
+++ b/app/cases/services/caseService.js
@@ -243,7 +243,7 @@ export default class CaseService {
          *  Intended to be called only after user is logged in and has account details
          *  See securityService.
          */
-        this.populateUsers = () => {
+        this.populateUsers = () => {            
             if (securityService.loginStatus.authedUser.org_admin) {
                 this.usersLoading = true;
                 var accountNumber;
@@ -298,6 +298,9 @@ export default class CaseService {
             this.redhatUsersLoading = true;
             return strataService.accounts.users(accountNumber).then((users) => {
                 this.redhatUsers = users;
+                if (securityService.loginStatus.authedUser.is_internal && !_.find(this.redhatUsers, { sso_username: securityService.loginStatus.authedUser.sso_username })) {
+                    this.redhatUsers.unshift(securityService.loginStatus.authedUser);
+                }
                 this.redhatUsersLoading = false;
             });
         };


### PR DESCRIPTION
@vrathee @engineersamuel Please review.

https://projects.engineering.redhat.com/browse/PCM-4356

The problem here is we fetch RH users only from account 540155 while there are many RH accounts. This prevented users from using the "Add me as watcher" button. To quickly workaround the problem, I am always adding `authedUser` to the RH users list if he's internal.