### PR TITLE
PCM-4424: Not resetting groups when a case is opened

### DIFF
--- a/app/cases/services/caseService.js
+++ b/app/cases/services/caseService.js
@@ -191,7 +191,6 @@ export default class CaseService {
             this.products = [];
             this.statuses = [];
             this.severities = [];
-            this.groups = [];
             this.account = {};
             this.comments = [];
             this.bugzillaList = {};


### PR DESCRIPTION
@gandhikeyur @engineersamuel Please review.

https://projects.engineering.redhat.com/browse/PCM-4424

IMO there is no need to reset `CaseService.groups` in `clearCase`, because those are case groups of the authedUser and thus are not dependent on a case.