### PR TITLE
PCM-4436: add maxlength 255 to hostname field in edit page to avoid error message

### DIFF
--- a/app/cases/views/detailsSection.jade
+++ b/app/cases/views/detailsSection.jade
@@ -75,6 +75,7 @@ section.case-description
                 .label {{::'Hostname'|translate}}
               .col-xs-4.col-sm-5.col-md-6
                 input#rha-case-hostname.form-control(
+                  maxlength='255',
                   ng-model='CaseService.kase.hostname',
                   name='hostname')
         .row.row-short(ng-show="CaseService.account.has_enhanced_sla || CaseService.kase.enhanced_sla")


### PR DESCRIPTION
@renujhamtani @jtrantin please review.

I forgot to add the maxlength on edit page. Adding this will help to avoid the error message.