### PR TITLE
PCM-4466: Let external org-admins create case on their managed accounts

### DIFF
--- a/app/cases/controllers/new.js
+++ b/app/cases/controllers/new.js
@@ -109,6 +109,9 @@ export default class New {
             CaseService.clearCase();
             RecommendationsService.clear();
             ProductsService.clear();
+            if(RHAUtils.isEmpty(CaseService.account.number)) {
+                CaseService.account.number = securityService.loginStatus.authedUser.account_number;
+            }
             CaseService.populateUsers().then(function () {
                 $scope.usersOnAccount = angular.copy(CaseService.users);
                 for (var i = $scope.usersOnAccount.length - 1; i >= 0; i--) {
@@ -221,6 +224,11 @@ export default class New {
                 CaseService.kase.description = search.description;
             }
         };
+
+        $scope.userHasManagedAccounts = () => (
+            RHAUtils.isNotEmpty(securityService.loginStatus.authedUser.managedAccounts) &&
+            RHAUtils.isNotEmpty(securityService.loginStatus.authedUser.managedAccounts.accounts)
+        );
 
         $scope.ABTestRegister = function () {
 

--- a/app/cases/views/accountSelect.jade
+++ b/app/cases/views/accountSelect.jade
@@ -1,13 +1,15 @@
 div(style='display: inline-block; padding-right: 10px;')
-  input#rha-account-number.form-control(style='width: 100%', ng-model='CaseService.account.number', ng-blur='populateAccountSpecificFields(CaseService.account.number)', ng-change='CaseService.sendCreationStartedEvent($event)')
+  input#rha-account-number.form-control(style='width: 100%', ng-model='CaseService.account.number', ng-blur='populateAccountSpecificFields(CaseService.account.number)',
+    ng-change='CaseService.sendCreationStartedEvent($event)',
+    ng-disabled="!securityService.loginStatus.authedUser.is_internal")
 span(ng-if='securityService.loginStatus.authedUser.is_internal', rha-bookmark-account, account='CaseService.account')
 div(style='display: inline-block;')
   span.link(ng-click='selectUserAccount()', ng-hide='loadingAccountNumber', translate='') Find My Account Number
   .spinner.spinner-inline(ng-show='loadingAccountNumber') &nbsp;
 .row.row-short
-  div.col-xs-10.col-sm-5
+  div.col-xs-10.col-sm-5(ng-show="securityService.loginStatus.authedUser.is_internal")
       div(rha-bookmarked-accounts-select='', selected-account='CaseService.account.number', selected-account-changed='populateAccountSpecificFields(accountNumber)')
-  div.col-xs-2.col-sm-1
+  div.col-xs-2.col-sm-1(ng-show="securityService.loginStatus.authedUser.is_internal")
       a.btn.btn-primary.btn-app.bookmark-view-button(ng-href='{{bookmarkAccountUrl}}', uib-tooltip='{{"Manage Bookmarked Accounts"|translate}}', tooltip-placement="top", tooltip-append-to-body="true")
         i.icon-star-empty
         i.icon-users

--- a/app/cases/views/new.jade
+++ b/app/cases/views/new.jade
@@ -8,7 +8,7 @@ div(rha-header='', page='newCase')
                 section.case-new
                     section.config-options
                         #rha-case-main-options
-                            div(ng-if='$parent.securityService.loginStatus.authedUser.is_internal')
+                            div(ng-if='$parent.securityService.loginStatus.authedUser.is_internal || ($parent.securityService.loginStatus.authedUser.org_admin && $parent.userHasManagedAccounts())')
                                 label(for='rha-account-number',translate,translate-comment="Noun") Account
                                 div(rha-accountselect='')
                                 label(for='rha-owners-select',translate,translate-comment="Noun") Owner


### PR DESCRIPTION
@gandhikeyur Please review.

Surprisingly, the existing components ca be reused to full extent, I only changed when they are shown. Tested with internal/external org-admin/non-org-admin and all seems to be working fine.