### PR TITLE
Making sbr readonly and visible only if its linked to a secure support cases

### DIFF
--- a/app/cases/views/detailsSection.jade
+++ b/app/cases/views/detailsSection.jade
@@ -71,21 +71,21 @@ section.case-description
                         name='internalStatus',
                         ng-options='internalStatus for internalStatus in CaseService.internalStatuses',
                         ng-model='CaseService.kase.internal_status')
-                .row.row-short(ng-if='securityService.loginStatus.authedUser.is_internal && COMMON_CONFIG.isGS4')
+                .row.row-short(ng-if='showSbrGroups()')
                     .col-xs-4.col-sm-3.col-md-4
                         .label {{::'SBR Groups'|translate}}
                     .col-xs-4.col-sm-5.col-md-6
-                        //div
-                        //    span.label.label-default.sbr-label-mar-right(ng-repeat="sbrGroup in CaseService.kase.sbr_groups.sbr_group") {{sbrGroup}}
-                        select#rha-sbr-select.form-control(
-                        chosen,
-                        multiple,
-                        ng-disabled="true",
-                        width="'100%'",
-                        data-placeholder="{{'Select SBRs'|translate}}",
-                        name='sbrGroups',
-                        ng-options='sbrGroup for sbrGroup in CaseService.sbrList',
-                        ng-model='CaseService.kase.sbr_groups.sbr_group')
+                        div
+                            span.label.label-default.sbr-label-mar-right(ng-repeat="sbrGroup in CaseService.kase.sbr_groups.sbr_group") {{sbrGroup}}
+                        //select#rha-sbr-select.form-control(
+                        //chosen,
+                        //multiple,
+                        //ng-disabled="true",
+                        //width="'100%'",
+                        //data-placeholder="{{'Select SBRs'|translate}}",
+                        //name='sbrGroups',
+                        //ng-options='sbrGroup for sbrGroup in CaseService.sbrList',
+                        //ng-model='CaseService.kase.sbr_groups.sbr_group')
                 .row.row-short
                     .col-xs-4.col-sm-3.col-md-4
                         .label {{::'Case Group'|translate}}


### PR DESCRIPTION
@renujhamtani Merging this as this is needed for Monday secure support release and the sbr changes are not working as expected, hence I have to again disable this field in QA.

