### PR TITLE
PCM 5052 : reading object from url and filling new case fields

### DIFF
--- a/app/cases/services/caseService.js
+++ b/app/cases/services/caseService.js
@@ -63,6 +63,7 @@ export default class CaseService {
         this.redhatUsers = [];
         this.redhatSecureSupportUsers = [];
         this.managedAccount = null;
+        this.externalCaseCreateKey;
         this.internalStatuses= [
             "Unassigned",
             "Waiting on Customer",
@@ -679,6 +680,11 @@ export default class CaseService {
                 AlertService.addSuccessMessage(gettextCatalog.getString('Successfully created case number {{caseNumber}}', {caseNumber: caseNumber}));
                 self.clearLocalStorageCacheForNewCase();
                 deferred.resolve(caseNumber);
+                // TODO - Send the newly created case number to API as mentioned in PCM-5350
+                // Once, the data is sent, delete the caseCreateKey entry from localStorage
+                if(RHAUtils.isNotEmpty(self.externalCaseCreateKey) && self.externalCaseCreateKey.includes('se-')) {
+                    self.localStorageCache.remove(self.externalCaseCreateKey);
+                }
             }, function (error) {
                 AlertService.clearAlerts();
                 AlertService.addStrataErrorMessage(error);


### PR DESCRIPTION
@engineersamuel @vrathee @kunyan @renujhamtani  Please review.

https://projects.engineering.redhat.com/browse/PCM-5052 

As of now, I have hardcoded a few lines to manually put a new case object in the localStorage cache for testing.

**Note :** I would be removing it in once the solution engine or container catalog are ready with their changes.

The flow would be as furnished below:

1) Solution engine & Container Catalog to store case creation details in local storage and pass the local storage key as the paramter in the new case url like https://access.qa.redhat.com/support/cases/#/case/new?caseCreateKey=cc-123456

2) PCM to read this caseCreateKey and fetch the stringified object from localStorage cache, parse it to get actual JSON object and fill the details in the respective fields on the case create page.

3) For Container Catalog, PCM would be removing the localStorage cache object right after populating the case fields. 
However, for Solution engine, PCM would have to retain the localStorage cache object till the user creates the case and the case number has to be passed to their API along with some more details(specificallu GUID) that they would have stored in the localStorage cache object. Once this API request is submitted and response is received, PCM would be deleting the localStorage cache object that is received via Solution engine.

More details on the approach can be found @ https://docs.google.com/document/d/1uA773GmMayhpSW0QfckPgiqlPvlAwS0dPbslCf-pJZc/edit 