### PR TITLE
PCM 5159 opening solution engine in the same tab as that of PCM

### DIFF
--- a/app/cases/views/list.jade
+++ b/app/cases/views/list.jade
@@ -20,7 +20,7 @@ div(ng-hide='showCaseList()')
                             a.btn.btn-app.btn-sm(translate='',translate-comment='Verb', ng-click='closeCases()', ng-disabled='!caseChosen()', ng-class="{'btn-primary': caseChosen() }") Close Case(s)
                         div(style='padding-top: 10px;')
                             span {{'Find answers faster with '|translate}}
-                                a(target="_blank",href='/solution-engine') Solution Engine
+                                a(href='/solution-engine') Solution Engine
     .row(ng-hide='!CaseService.sfdcIsHealthy || SearchCaseService.totalCases == 0')
         .col-sm-6
             .case-count


### PR DESCRIPTION
@renujhamtani Merging this.

As per the discussion in the jira PCM-5159 , opening solution engine in the same tab as that of PCM when the user clicks on Solution engine hyperlink on case list page.