### PR TITLE
Stage Chat window fix : Using https in the chatIframeHackUrlPrefix

### DIFF
--- a/app/main.module.js
+++ b/app/main.module.js
@@ -191,7 +191,7 @@ if (ENVIRONMENT === 'gs4') {
                     CHAT_SUPPORT.chatLiveAgentUrlPrefix = 'https://d.la2-c1cs-ord.salesforceliveagent.com/chat';
                     CHAT_SUPPORT.chatInitHashOne = '572A0000000GmiP';
                     CHAT_SUPPORT.chatInitHashTwo = '00D3F000000CmV8';
-                    CHAT_SUPPORT.chatIframeHackUrlPrefix = 'http://stage2-rogsstest.cs92.force.com/chatHidden';
+                    CHAT_SUPPORT.chatIframeHackUrlPrefix = 'https://stage2-rogsstest.cs92.force.com/chatHidden';
                 } else {
                     if (host === 'access.redhat.com') {
                         CHAT_SUPPORT.chatButtonToken = '573A0000000GmiP';


### PR DESCRIPTION
@renujhamtani @engineersamuel @anujsi Please review.

Made these changes as per the mail by pcon, that the stage url is not https and hence the chat functionality is not working in PCM stage.

This can be merged as this functionality is only limited till stage environment.
