### PR TITLE
Fixing 401 error call for s3config, executing call after init success

### DIFF
--- a/app/cases/services/attachmentsService.js
+++ b/app/cases/services/attachmentsService.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import hydrajs from '../../shared/hydrajs';
 
 export default class AttachmentsService {
-    constructor($q, $sce, $state, $window, $location, $rootScope, $timeout, RHAUtils, strataService, HeaderService, TreeViewSelectorUtils, $http, securityService, AlertService, CaseService, gettextCatalog) {
+    constructor($q, $sce, $state, $window, $location, $rootScope, $timeout, RHAUtils, strataService, HeaderService, TreeViewSelectorUtils, $http, securityService, AlertService, CaseService, gettextCatalog, AUTH_EVENTS) {
         'ngInject';
 
         this.originalAttachments = [];
@@ -368,6 +368,12 @@ export default class AttachmentsService {
             });
         };
 
-        this.init();
+        if (securityService.loginStatus.isLoggedIn) {
+            this.init();
+        }
+
+        $rootScope.$on(AUTH_EVENTS.loginSuccess, angular.bind(this, function () {
+            this.init();
+        }));
     }
 }


### PR DESCRIPTION
@vrathee @anujsi @jeudy100 Please review

While debugging with najain, we observed that the s3 config calls were getting executed even before the init of the app and hence the cookies were not getting parsed in the Api call which resulted in 401 errors randomly for s3 configs.
Having s3 config result is much needed for the new uploader functionality to work.

I did not have a jira number handy, hence I have not tagged any jira in this PR.