### PR TITLE
PCM-8633 - In support cases, set both comments and input text box to fixed-width font

### DIFF
--- a/app/assets/sass/components/_case-discussion.scss
+++ b/app/assets/sass/components/_case-discussion.scss
@@ -14,7 +14,8 @@
 		margin-top: 10px;
 	}
 	textarea.comment {
-	    margin-bottom: 15px;
+		margin-bottom: 15px;
+		font-family: monospace;
 	}
 	.comment {
 		textarea { min-height: 250px; }
@@ -23,6 +24,9 @@
 		.comment { @include rem('padding-left', 28px); }
 		.private { color: red; }
 		blockquote { margin-bottom: 0; }
+		.pre-text {
+			font-family: monospace;
+		}
 	}
 
 	.tab-pane { padding: 0; }
@@ -138,7 +142,7 @@
 	}
 
 	.byline {
-		font-family: 'Overpass';
+		font-family: "Red Hat Text","Overpass",Helvetica,sans-serif !important;
 		font-weight: 700;
 		@include font-size(13px);
 		font-size: 13px;


### PR DESCRIPTION
Recently we have changed our base font family to 'Red Hat Text' from 'Overpass' while doing that we have also changed the default font family of pre and form elements to  'Red Hat Text' from 'monospace' font hence the alignment of texts (specifically logs) were broken. 