### PR TITLE
show cluster id on details page if present in response irrespective of product selected

### DIFF
--- a/app/cases/controllers/productSelect.js
+++ b/app/cases/controllers/productSelect.js
@@ -69,7 +69,6 @@ export default class ProductSelect {
             }
             if (!ProductsService.showClusterIdFieldForSelectedProduct()) {
                 CaseService.kase.openshiftClusterID = "";
-                CaseService.kase.openshift_cluster_id = "";
             }
             CaseService.validateNewCase();
             ProductsService.getVersions(CaseService.kase.product);

--- a/app/cases/views/detailsSection.jade
+++ b/app/cases/views/detailsSection.jade
@@ -54,7 +54,7 @@ section.case-description
                         .label {{::'Product Version'|translate}}
                     .col-xs-4.col-sm-5.col-md-6
                         div(rha-versionselect='')
-                .row.row-short(ng-if='ProductsService.showClusterIdFieldForSelectedProduct()')
+                .row.row-short(ng-if='CaseService.kase.openshift_cluster_id !== undefined || ProductsService.showClusterIdFieldForSelectedProduct()')
                     .col-xs-4.col-sm-3.col-md-4
                         .label {{::'Openshift Cluster ID'|translate}}
                             span &nbsp;


### PR DESCRIPTION
@vrathee @anujsi Please review.
We will show cluster id on details page if it is present in case details response even if selected product is not Openshift Online.But if product is not openshift online and no cluster id is set we will not show it. This is how SFDC is doing it and Eric Rich suggested doing it the same way in PCM.